### PR TITLE
Allow array of full ip range generator to support other netmasks than /24

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,9 +53,9 @@ Arpping.prototype._getFullRange = function(ip, mask = 24) {
     ip = ip + '/' + mask;
 
     var range = [];
-    var block = new Netmask(ips);
+    var block = new Netmask(ip);
     range.push(block.base);
-    range.forEach((ip, _, index) => range.push(ip));
+    block.forEach((ip, _, index) => range.push(ip));
     range.push(block.broadcast);
     return this.includeEndpoints ? 
         range:

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ function Arpping({ timeout = 5, includeEndpoints = false, useCache = true, cache
 /**
 * Build array of full ip range (xxx.xxx.xxx.1-255) given example ip address
 * @param {String} ip
+* @param {Number} mask
 */
 Arpping.prototype._getFullRange = function(ip, mask = 24) {
     // don't use default assignment so false-y values are overwritten
@@ -54,7 +55,7 @@ Arpping.prototype._getFullRange = function(ip, mask = 24) {
     var range = [];
     var block = new Netmask(ips);
     range.push(block.base);
-    range.forEach((ip, _, _) => range.push(ip));
+    range.forEach((ip, _, index) => range.push(ip));
     range.push(block.broadcast);
     return this.includeEndpoints ? 
         range:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,11 @@
       "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
       "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
     },
+    "netmask": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
+    },
     "os": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "child_process": "^1.0.2",
+    "netmask": "^1.0.6",
     "os": "^0.1.1"
   },
   "devDependencies": {},


### PR DESCRIPTION
The array of full ip range generator was limited to /24 netmasks like 192.168.1.0/24.
Using the netmask package it now supports all kinds of netmasks like 10.0.0.0/12 or 172.16.1/21.