### PR TITLE
Fixed typing errors. Exporting type definitions. Removed unecessary packages

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,23 +1,24 @@
 /// <reference types="node" />
-declare type Interface = 'lo0' | 'en0' | 'eth0' | 'wlan0';
-declare type Connection = {
+declare type OsType = 'Windows_NT' | 'Linux' | 'Darwin';
+export declare type Interface = 'lo0' | 'en0' | 'eth0' | 'wlan0';
+export declare type Connection = {
     name?: Interface;
     internal?: boolean;
     family?: 'IPv4' | 'IPv6';
     address?: string;
     netmask?: number | string;
 };
-declare type Device = {
-    os: 'Windows_NT' | 'Linux' | 'Darwin';
+export declare type Device = {
+    os: OsType;
     connection?: Connection | null;
     type?: string | null;
 };
-declare type InterfaceFilters = {
+export declare type InterfaceFilters = {
     interface?: Interface[];
     internal?: boolean[];
     family?: ('IPv4' | 'IPv6')[];
 };
-declare type Host = {
+export declare type Host = {
     ip: string;
     mac: string;
     name?: string;
@@ -25,7 +26,7 @@ declare type Host = {
     isHostDevice?: boolean;
     matched?: string[];
 };
-declare type Props = {
+export declare type Props = {
     timeout?: number;
     includeEndpoints?: boolean;
     useCache?: boolean;
@@ -98,7 +99,7 @@ declare class Arpping {
     *
     * @returns {string[]}
     */
-    _getFullRange(netmaskOverride?: number | string | undefined): any[];
+    _getFullRange(netmaskOverride?: number | string | undefined): string[];
     /**
     * Ping a range of ip addresses
     * @param {string[]} [range] - array of ip addresses to ping, defaults to full netmask range

--- a/dist/index.js
+++ b/dist/index.js
@@ -59,12 +59,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-var os = require('os');
-var Netmask = require('netmask').Netmask;
-var execFile = require('child_process').execFile;
+var os_1 = __importDefault(require("os"));
+var child_process_1 = require("child_process");
+var netmask_1 = require("netmask");
 var macLookup_1 = __importDefault(require("./macLookup"));
 var flag;
-var osType = os.type();
+var osType = os_1.default.type();
 var arpFlag = osType === 'Windows_NT' ? ['-a'] : [];
 switch (osType) {
     case 'Windows_NT':
@@ -120,7 +120,7 @@ var Arpping = /** @class */ (function () {
     * @returns {object} list of available interfaces organized by interface name
     */
     Arpping.getNetworkInterfaces = function () {
-        return os.networkInterfaces();
+        return os_1.default.networkInterfaces();
     };
     /**
     * Filter network interfaces to find active internet connections
@@ -171,13 +171,19 @@ var Arpping = /** @class */ (function () {
     * @returns {string[]}
     */
     Arpping.prototype._getFullRange = function (netmaskOverride) {
+        var _a, _b;
         if (!this.myDevice.connection) {
             if (this.debug)
                 console.log("No connection available");
             return [];
         }
-        var _a = this.myDevice.connection, address = _a.address, netmask = _a.netmask;
-        var block = new Netmask(address, netmaskOverride || netmask);
+        var _c = this.myDevice.connection, address = _c.address, netmask = _c.netmask;
+        if (!address) {
+            if (this.debug)
+                console.log("No address available");
+            return [];
+        }
+        var block = new netmask_1.Netmask(address, (_b = (_a = (netmaskOverride !== null && netmaskOverride !== void 0 ? netmaskOverride : netmask)) === null || _a === void 0 ? void 0 : _a.toString()) !== null && _b !== void 0 ? _b : '24');
         var range = [];
         if (this.includeEndpoints) {
             range.push(block.base);
@@ -209,7 +215,7 @@ var Arpping = /** @class */ (function () {
                                 throw new Error('No connection!');
                         }
                         pings = range.map(function (ip) { return new Promise(function (resolve, reject) {
-                            execFile('ping', [flag, _this.timeout, ip], function (err, stdout) {
+                            (0, child_process_1.execFile)('ping', [flag, _this.timeout.toString(), ip], function (err, stdout) {
                                 if (err || stdout.match(/100(\.0)?% packet loss/g))
                                     return reject(ip);
                                 return resolve(ip);
@@ -247,7 +253,7 @@ var Arpping = /** @class */ (function () {
                         if (!this.myDevice.connection)
                             throw new Error('No connection!');
                         arps = range.map(function (ip) { return new Promise(function (resolve, reject) {
-                            execFile('arp', __spreadArray(__spreadArray([], arpFlag, true), [ip], false), function (err, stdout) {
+                            (0, child_process_1.execFile)('arp', __spreadArray(__spreadArray([], arpFlag, true), [ip], false), function (err, stdout) {
                                 if (err || stdout.includes('no entry') || stdout.includes('(incomplete)'))
                                     return reject(ip);
                                 var _a = (stdout.match(/([0-9A-Fa-f]{1,2}[:-]){5}([0-9A-Fa-f]{1,2})/ig) || [])[0], mac = _a === void 0 ? null : _a;
@@ -256,7 +262,7 @@ var Arpping = /** @class */ (function () {
                                 var host = { ip: ip, mac: mac, type: (0, macLookup_1.default)(mac) };
                                 if (ip === _this.myDevice.connection.address)
                                     host.isHostDevice = true;
-                                execFile('nslookup', [ip], function (err, stdout) {
+                                (0, child_process_1.execFile)('nslookup', [ip], function (err, stdout) {
                                     if (!err) {
                                         var _a = (stdout.match(/ = .*/) || [])[0], name_2 = _a === void 0 ? null : _a;
                                         if (!!name_2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,10 @@
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
-        "child_process": "^1.0.2",
-        "netmask": "^1.0.6",
-        "os": "^0.1.1"
+        "netmask": "^2.0.2"
       },
       "devDependencies": {
+        "@types/netmask": "^1.0.30",
         "@types/node": "^18.0.3",
         "ts-loader": "^9.3.1",
         "typescript": "^4.7.4"
@@ -118,6 +117,12 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/@types/netmask": {
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/@types/netmask/-/netmask-1.0.30.tgz",
+      "integrity": "sha512-Kl1xAICLv1Y7/WsNXkPKldRMz3QmXUYMIzr3rMXnIBDy9c4/sYG7V6P6u7Ja3w+uNtNQrRudJduqVoYX/DxfZg==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "18.0.3",
@@ -446,11 +451,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -755,9 +755,9 @@
       "peer": true
     },
     "node_modules/netmask": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
-      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -768,11 +768,6 @@
       "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/os": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -1226,6 +1221,12 @@
       "dev": true,
       "peer": true
     },
+    "@types/netmask": {
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/@types/netmask/-/netmask-1.0.30.tgz",
+      "integrity": "sha512-Kl1xAICLv1Y7/WsNXkPKldRMz3QmXUYMIzr3rMXnIBDy9c4/sYG7V6P6u7Ja3w+uNtNQrRudJduqVoYX/DxfZg==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.0.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
@@ -1498,11 +1499,6 @@
         "supports-color": "^7.1.0"
       }
     },
-    "child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
-    },
     "chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -1751,9 +1747,9 @@
       "peer": true
     },
     "netmask": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.1.tgz",
-      "integrity": "sha512-gB8eG6ubxz67c7O2gaGiyWdRUIbH61q7anjgueDqCC9kvIs/b4CTtCMaQKeJbv1/Y7FT19I4zKwYmjnjInRQsg=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
     },
     "node-releases": {
       "version": "2.0.5",
@@ -1761,11 +1757,6 @@
       "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==",
       "dev": true,
       "peer": true
-    },
-    "os": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
     },
     "picocolors": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,10 @@
   "description": "Discover and search for internet-connected devices (locally) using ping and arp",
   "main": "dist/index.js",
   "dependencies": {
-    "child_process": "^1.0.2",
-    "netmask": "^2.0.1",
-    "os": "^0.1.1"
+    "netmask": "^2.0.2"
   },
   "devDependencies": {
+    "@types/netmask": "^1.0.30",
     "@types/node": "^18.0.3",
     "ts-loader": "^9.3.1",
     "typescript": "^4.7.4"


### PR DESCRIPTION
Hey there!

I've done three minor changes in this PR:
- Fixed typing errors: When checking out the code, the TypeScript linter complained about incorrectly assigned types, they should all be fixed now.
- Exporting type definitions: In a project where I use this library, I wanted to import types but they were not exported. This is now addressed.
- Removed unnecessary packages: Inside the `package.json` file, the packages `os` and `child_process` were defined. These are part of NodeJS and do not need to be specified. They still exist in NPM to prevent them from being squatted by bad actors but don't do anything in particular (I think). Removing them is safer.

I'm working on the MAC address lookup functionality in the meantime. I'm hoping to get it done soon 🙂 Thanks for the library btw, it's exactly what I was looking for!